### PR TITLE
Update devcontainer and CI to use Node 16

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "name": "home-assistant/yellow.home-assistant.io",
+  "image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:16",
+  "postCreateCommand": "npm install",
+  "appPort": 5000,
+  "extensions": ["esbenp.prettier-vscode"]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,0 @@
-{
-  "name": "Improv WiFi website",
-  "image": "mcr.microsoft.com/vscode/devcontainers/typescript-node:14",
-  "postCreateCommand": "npm install",
-  "context": "..",
-  "appPort": 5000,
-  "extensions": ["esbenp.prettier-vscode"]
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
This matches https://github.com/home-assistant/yellow.home-assistant.io/blob/main/.node-version