### PR TITLE
Set opening case order to 0

### DIFF
--- a/src/procedures/opening-case.html
+++ b/src/procedures/opening-case.html
@@ -3,7 +3,7 @@ tags:
   - poe
   - powersupply
   - add-sdd-existing-installation
-order: 1
+order: 0
 procedures:
   - title: Opening the case
     steps:


### PR DESCRIPTION
Currently both opening the case and installing the CM4 have an order of 1. In the current version that is deployed you can see, for example on the [PoE page](https://yellow.home-assistant.io/poe/), that we first need to install the CM4, then open the case and close it again?

Not sure if setting it to 0 is the best way or if you prefer to keep 1 for opening the case and move all other pages down in the order?