### PR TITLE
Redirect yellow.home-assistant.io/<serial> to main page

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,3 @@
 /ce             /resources/Yellow_DoC_EU.pdf
 /ukca           /resources/Yellow_DoC_UKCA.pdf
+/2*             /


### PR DESCRIPTION
The serial number QR code on Yellow is prepended with the URL. We don't have any specific use for the URL right now, just redirect people to the main site.