### PR TITLE
Clarify steps for serial port debuggong on macOS

### DIFF
--- a/src/_includes/style.css
+++ b/src/_includes/style.css
@@ -35,6 +35,17 @@ h3 {
 .content img {
   max-width: 100%;
 }
+.content pre {
+  margin: 4px;
+  padding-left: 8px;
+}
+.content kbd {
+  padding-left: 4px;
+  padding-right: 4px;
+  border: 1px solid #ccc;
+  background-color: #f0f0f0;
+  border-radius: 4px;
+}
 
 /* FOOTER STYLES */
 .footer {

--- a/src/guides/use-serial-console-linux-macos.html
+++ b/src/guides/use-serial-console-linux-macos.html
@@ -47,7 +47,8 @@ guideName: Using the serial console for debugging (Linux/macOS)
     </li>
     <li>
       <span>Start GNU Screen and point it to this USB port. E.g.:
-        <pre><code>sudo screen /dev/ttyUSB0 115200</code></pre>
+        <pre><code>screen /dev/ttyUSB0 115200</code></pre>
+        <p><b>Note:</b> If your account does not have permission to access serial ports, you may have to run the command with <code>sudo</code>.</p>
         <p><b>Note:</b> Screen typically doesn't display anything on startup. You see only the cursor
           on the top left of the window.</p>
       </span>

--- a/src/guides/use-serial-console-linux-macos.html
+++ b/src/guides/use-serial-console-linux-macos.html
@@ -11,13 +11,16 @@ guideName: Using the serial console for debugging (Linux/macOS)
   <p><span></span></p>
   <ol start="1">
     <li>
+      <span>Power off and unplug Yellow.</span>
+    </li>
+    <li>
       <span>Make sure JP1 is set to UART.</span>
     </li>
     <li>
       <span>Make sure <i>GNU Screen</i> is installed on your system.</span>
       <ul>
         <li>On Linux, use your distribution's package manager (e.g. <code>sudo apt install screen</code>).</li>
-        <li>On macOS, use <a href="https://formulae.brew.sh/formula/screen">Homebrew</a>.</li>
+        <li>On macOS, use <a href="https://formulae.brew.sh/formula/screen">Homebrew</a>: <code>brew install screen</code>.</li>
       </ul>
     </li>
     <li>
@@ -26,30 +29,36 @@ guideName: Using the serial console for debugging (Linux/macOS)
     <li>
       <span>List the USB port numbers:</span>
       <ul>
-        <li>On Linux, use <br><code>ls /dev/ttyUSB*</code></li>
-        <li>On macOS, use <br><code>ls /dev/cu.usbserial-*</code><br>(If the Silicon Labs CP2102N driver is installed, use <code>ls /dev/cu.SLAB_USBtoUART*</code>)</li>
+        <li>On Linux, use <pre><code>ls /dev/ttyUSB*</code></pre></li>
+        <li>On macOS, use <pre><code>ls /dev/cu.*</code></pre> If the Silicon Labs CP2102N driver is installed, you will see both <code>/dev/cu.SLAB_USBtoUART</code> and <code>/dev/cu.usbserial-110</code> (<code>/dev/cu.usbserial-210</code>, depending on which port the Yellow is plugged in to).</li>
       </ul>
     </li>
     <li>
-      <span>Setup a USB connection: Yellow: USB-C, PC: USB type A.</span>
-    </li>
-    <li>
-      <span>List the USB port numbers again (see step 4). The new entry is for Yellow.</span>
+      <span>Connect the Yellow with USB C to your computer.</span>
       <p>
-        <b>Note:</b> In case no new entry appears, make sure JP1 is at the right position (step 1) and your USB-C cable supports at least USB 2.0 signals (try using a different USB-C cable if in doubt).
+        <b>Note:</b> Since Yellow is not powered on yet, it is normal for no lights to be on.
       </p>
     </li>
     <li>
-      <span>Start GNU Screen and point it to this USB port. E.g.: <br>
-        <code>sudo screen /dev/ttyUSB0 115200</code>. <br>
+      <span>List the USB port numbers again (see step 5). The new entry is for Yellow.</span>
+      <p>
+        <b>Note:</b> In case no new entry appears, make sure JP1 is at the right position (step 2) and your USB-C cable supports at least USB 2.0 signals (try using a different USB-C cable if in doubt).
+      </p>
+    </li>
+    <li>
+      <span>Start GNU Screen and point it to this USB port. E.g.:
+        <pre><code>sudo screen /dev/ttyUSB0 115200</code></pre>
         <p><b>Note:</b> Screen typically doesn't display anything on startup. You see only the cursor
           on the top left of the window.</p>
       </span>
     </li>
     <li>
-      <span>Hit the <b>Enter</b> key until prompted for credentials.
+      <span>Power the Yellow back on with either the DC adapter or Power over Ethernet (if supported).</span>
+    </li>
+    <li>
+      <span>After the Yellow finishes booting, hit the <b>Enter</b> key until prompted for credentials.
         <ul>
-          <li>Homeassistant login: root</li>
+          <li>Homeassistant login: <code>root</code></li>
           <li>No password is required. Hit the <b>Enter</b> key.</li>
         </ul>
       </span>
@@ -57,11 +66,11 @@ guideName: Using the serial console for debugging (Linux/macOS)
     <li>
       <span>The console offers the Home Assistant CLI under the command <code>ha</code>. The command allows to get information about the state of the system. Typically useful commands are:
         <ul>
-          <li>To print the supervisor logs, type <br>
-            <code>ha supervisor logs</code>
+          <li>To print the supervisor logs, type
+            <pre><code>ha supervisor logs</code></pre>
           </li>
-          <li>To print out the network info, type <br>
-            <code>ha network info</code>
+          <li>To print out the network info, type
+            <pre><code>ha network info</code></pre>
           </li>
         </ul>
       </span>
@@ -69,14 +78,14 @@ guideName: Using the serial console for debugging (Linux/macOS)
     <li>To save the boot log into a file, perform the following steps:
       <ol>
         <li>Power off Yellow.</li>
-        <li>Perform steps 1&ndash;7.</li>
+        <li>Perform steps 1&ndash;11.</li>
         <li>Power up Yellow.</li>
-        <li>To save the bootlogs, type <br>
-          <code>Ctrl+a</code>
-          <code>:hardcopy -h /tmp/boot.log</code>
+        <li>To save the bootlogs, press <kbd>Ctrl</kbd>+<kbd>A</kbd> and then type
+          <pre><code>:hardcopy -h /tmp/boot.log</code></pre>
         </li>
       </ol>
     </li>
+    <li>To exit GNU Screen, press <kbd>Ctrl</kbd>+<kbd>A</kbd> and then <kbd>D</kbd>.</li>
   </ol>
   <p><span>Resources:</span></p>
   <p>


### PR DESCRIPTION
`/dev/cu.SLAB_USBtoUART` and `/dev/cu.usbserial-110` do not exist on macOS if nothing is plugged in.

I also added `<kbd>` styling and moved code blocks into `<pre>` elements with a bit of indentation for clarity:

<img width="454" alt="image" src="https://user-images.githubusercontent.com/32534428/204350685-8884ef4c-74c0-4711-b355-b9367344af1a.png">
