### PR TITLE
Rename 'support' to 'faq'.

### DIFF
--- a/src/_includes/base.liquid
+++ b/src/_includes/base.liquid
@@ -19,8 +19,8 @@ menu:
       - /resources/
       - /videos/
     - Documentation
-  - - - /support/
-    - Support
+  - - - /faq/
+    - FAQ
 ---
 
 {% comment %}

--- a/src/faq.html
+++ b/src/faq.html
@@ -1,6 +1,6 @@
 ---
 layout: base
-description: Support | Yellow
+description: FAQ | Yellow
 faqs:
   - title: >
       I can’t access the system via http://homeassistant.local:8123, what can


### PR DESCRIPTION
- Align with terminology used on SkyConnect page.