### PR TITLE
Add redirects for FAQ entries

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,4 @@
 /ce             /resources/Yellow_DoC_EU.pdf
 /ukca           /resources/Yellow_DoC_UKCA.pdf
 /2*             /
+/support/*	/faq/:splat


### PR DESCRIPTION
With #104 links to FAQ entries already shared in forums/via email got broken. Fix them by adding a redirect.