### PR TITLE
NVMe setup procedures: add 'moving data' steps

### DIFF
--- a/src/procedures/poe-nvme.html
+++ b/src/procedures/poe-nvme.html
@@ -26,3 +26,4 @@ tools:
 {% render "proc.include.liquid", proc: procedureInstallNvme %}
 {% render "proc.include.liquid", proc: procedureReassembleCase %}
 {% render "proc.include.liquid", proc: proceduresInstallingHAOS %}
+{% render "proc.include.liquid", proc: procedureMoveDataDisk %}

--- a/src/procedures/power-supply-nvme.html
+++ b/src/procedures/power-supply-nvme.html
@@ -26,3 +26,4 @@ tools:
 {% render "proc.include.liquid", proc: procedureInstallNvme %}
 {% render "proc.include.liquid", proc: procedureReassembleCase %}
 {% render "proc.include.liquid", proc: proceduresInstallingHAOS %}
+{% render "proc.include.liquid", proc: procedureMoveDataDisk %}

--- a/src/procedures/procedures.11tydata.yaml
+++ b/src/procedures/procedures.11tydata.yaml
@@ -246,7 +246,8 @@ procedureMoveDataDisk:
       image: ha-config-storage.png
       content: |
         <ul>
-          <li>
+          <li class="warning"><b>CM4 Lite</b>: If you have a Raspberry&nbsp;Compute&nbsp;Module&nbsp;4&nbsp;Lite: As there is no eMMC&nbsp;flash, you can skip this and the following steps.</li>
+          <li class="info"><b>Regular CM4 modules</b>: This <i>moving your data</i> procedure is required, even if your module is new.<li>
             Open your Home Assistant instance and navigate to the storage configuration page using the button below:<br><br>
             <a href="https://my.home-assistant.io/redirect/storage/" target="_blank"><img
               src="https://my.home-assistant.io/badges/storage.svg"

--- a/src/procedures/procedures.11tydata.yaml
+++ b/src/procedures/procedures.11tydata.yaml
@@ -247,7 +247,7 @@ procedureMoveDataDisk:
       content: |
         <ul>
           <li class="warning"><b>CM4 Lite</b>: If you have a Raspberry&nbsp;Compute&nbsp;Module&nbsp;4&nbsp;Lite: As there is no eMMC&nbsp;flash, you can skip this and the following steps.</li>
-          <li class="info"><b>Regular CM4 modules</b>: This <i>moving your data</i> procedure is required, even if your module is new.<li>
+          <li class="info"><b>Regular CM4 modules</b>: This <i>moving your data</i> procedure is required for making use of your SSD, even if your module is new.<li>
             Open your Home Assistant instance and navigate to the storage configuration page using the button below:<br><br>
             <a href="https://my.home-assistant.io/redirect/storage/" target="_blank"><img
               src="https://my.home-assistant.io/badges/storage.svg"


### PR DESCRIPTION
- add missing steps on moving the data from eMMC to NMVe
- add info that these moving data steps are not required for Yellows running on CM4 Lite, as they do not have eMMC