### PR TITLE
Add the Samsung 980 Pro to the list of unsupported SSDs

### DIFF
--- a/src/faq.html
+++ b/src/faq.html
@@ -144,6 +144,7 @@ faqs:
           <li>SK Hynix BC711</li>
           <li>Crucial P2 CT250P2SSD8</li>
           <li>Lexar NM620</li>
+          <li>Samsung 980 Pro</li>
         </ul>
         Usually, if one model doesn't work, other models from the same product
         family have a high chance to be affected as well. Other models may work,


### PR DESCRIPTION
I found my Samsung 980 Pro would not cooperate with the Yellow PoE when trying to install. After attempting a significant number of workarounds, I had to give up. I was expecting it to work since I think I've used it previously with a CM4.