### PR TITLE
Document installation onto NVMe feature

### DIFF
--- a/src/guides/yellow-leds.html
+++ b/src/guides/yellow-leds.html
@@ -77,15 +77,15 @@ guideName: Home Assistant Yellow LEDs
         <td>System is in EEPROM firmware or boot loader mode.</td>
       </tr>
       <tr>
-        <td>Heartbeat (typically ~45s)</td>
+        <td>Heartbeat (typically ~30s)</td>
         <td>Installer is booting.</td>
       </tr>
       <tr>
-        <td>Solid on (typically 3s)</td>
+        <td>Solid on (typically 5s)</td>
         <td>Installer successfully booted and was able to connect to the Internet.</td>
       </tr>
       <tr>
-        <td>Solid on (much longer than 3s)</td>
+        <td>Solid on (much longer than 5s)</td>
         <td>After the heartbeat sequence, the yellow LED should be solid on for about 3s and then switch to steady blinking. A yellow LED that does not switch to steady blinking but stays solid on indicates a network issue.</td>
       </tr>
       <tr>

--- a/src/procedures/procedures.11tydata.yaml
+++ b/src/procedures/procedures.11tydata.yaml
@@ -204,6 +204,9 @@ proceduresInstallingHAOS:
       content: |
         <ul>
           <li>If you are not using PoE, connect the power supply to Home&nbsp;Assistant&nbsp;Yellow&nbsp;Kit.</li>
+          <li class="info">Advanced: Home Assistant OS is installed onto the eMMC if available on your CM4. If you 
+          prefer installing the complete Home Assistant OS onto the NVMe SSD, press the blue button while the yellow LED
+          is on constantly (during the 5s window, see next step).</li>
         </ul>
     - title: Watching the LEDs
       image: led-patter-boot.webp
@@ -212,7 +215,7 @@ proceduresInstallingHAOS:
           <li>Wait for Home&nbsp;Assistant Yellow to start booting from the USB flash drive.</li>
           <li>During boot, the Yellow LED blinks in a heartbeat pattern.</li>
           <li>Once the installer is ready, the yellow LED is on constantly.</li>
-          <li>Installation will start automatically after 2-3 seconds.</li>
+          <li>Installation will start automatically after 5 seconds.</li>
           <li class="info">If the yellow LED does not start blinking steadily after a few seconds, but stays on constantly: This indicates that there might be a network issue.</li>
         </ul>
     - title: Waiting

--- a/src/procedures/procedures.11tydata.yaml
+++ b/src/procedures/procedures.11tydata.yaml
@@ -204,9 +204,13 @@ proceduresInstallingHAOS:
       content: |
         <ul>
           <li>If you are not using PoE, connect the power supply to Home&nbsp;Assistant&nbsp;Yellow&nbsp;Kit.</li>
-          <li class="info">Advanced: Home Assistant OS is installed onto the eMMC if available on your CM4. If you 
-          prefer installing the complete Home Assistant OS onto the NVMe SSD, press the blue button while the yellow LED
-          is on constantly (during the 5s window, see next step).</li>
+          <li class="info">For CM4 Lite Home Assistant OS is automatically installed on the NVMe SSD.
+            For regular CM4s Home Assistant OS is installed onto the eMMC by default.
+          </li>
+          <li class="info"><b>Advanced</b>: Forcing installation onto the NVMe SSD when using CM4 with eMMC:<  br>
+            Press the blue button while the yellow LED
+            is on constantly (during the 5s window, see next step).
+          </li>
         </ul>
     - title: Watching the LEDs
       image: led-patter-boot.webp


### PR DESCRIPTION
This feature is supported with the latest Home Assistant OS Installer for Yellow (see https://github.com/NabuCasa/yellow-buildroot/releases/tag/yellow-installer-20230405 and https://github.com/home-assistant/version/pull/285).