### PR TITLE
Yellow kit installation: troubleshoot constant heartbeat situation

### DIFF
--- a/src/documentation.html
+++ b/src/documentation.html
@@ -27,8 +27,6 @@ troubleshooting:
     url: /guides/yellow-leds/
   - title: Reinstall Raspberri Pi CM4 EEPROM firmware
     url: /guides/flash-cm4-firmware/
-  - title: Installation on Yellow kit - yellow LED keeps flashing
-    url: /guides/install-yellow-light-keeps-flashing-in-heartbeat/
 ---
 
 <div class="container">

--- a/src/guides/install-yellow-light-keeps-flashing-in-heartbeat.html
+++ b/src/guides/install-yellow-light-keeps-flashing-in-heartbeat.html
@@ -24,16 +24,42 @@ guideName: "Symptom: Installation on Yellow kit: yellow LED keeps blinking"
     <span>
       <ol>
         <li>Download the Yellow operating system.
-          <ul><li>Go to the <a href="https://github.com/home-assistant/operating-system/releases">operating system page</a> on github and download the latest version of the `haos_yellow-xx.x.img.xz` file.
-          </li></ul></li>
-          <li>Reinstall the operating system on Yellow. <ul><li>Open the procedure on <a href="/guides/reinstall-os/#install-os-rpiboot">how to reinstall the operating system</a>. </li><li>Follow the procedure <i>Option 2: Reinstall Home Assistant OS using rpiboot</i>  up to step 8.</li>
-          <li>In step 9, use the downloaded image instead of the image provided by the Raspberry Pi Imager.</li>
-          <li>Follow the rest of the steps to finish reinstalling the Yellow operating system.</li>
+          <ul><li>Go to the <a href="https://github.com/home-assistant/operating-system/releases">operating system page</a> on github and download the latest stable version of the `haos_yellow-xx.x.img.xz` file.
+          </li></ul>
+        </li>        
+        <li>
+          <span>Install rpiboot onto your computer.</span>
+          <ul>
+            <li>
+              <span
+                >Using
+                <a
+                  href="https://github.com/raspberrypi/usbboot/raw/master/win32/rpiboot_setup.exe"
+                  >Windows Installer</a
+                ></span
+              >
+            </li>
+            <li>
+              <span
+                >From 
+                <a
+                  href="https://www.raspberrypi.com/documentation/computers/compute-module.html#building-rpiboot-on-your-host-system-cygwinlinux"
+                  >source code</a
+                ></span
+              >
+            </li>
+          </ul>
+        </li>
+        <li>Reinstall the operating system on Yellow. 
+          <ul>
+            <li>Open the procedure on <a href="/guides/reinstall-os/#install-os-rpiboot">how to reinstall the operating system</a>. </li>
+            <li>Follow the procedure <i>Option 2: Reinstall Home Assistant OS using rpiboot</i>  up to step 8.</li>
+            <li>In step 9, use the downloaded image instead of the image provided by the Raspberry Pi Imager.</li>
+            <li>Follow the rest of the steps to finish reinstalling the Yellow operating system.</li>
             </ul></li>
         </li>
         <li>Your system should now start up.</li>
     </ol>
-      </span
-    >
+      </span>
   </p>
 </div>

--- a/src/guides/reinstall-os.html
+++ b/src/guides/reinstall-os.html
@@ -36,12 +36,12 @@ guideName: How to reinstall the operating system
     </li>
     <li>
       <span
-        >Within 3s (or from start), press and hold the red and blue button on
+        >Within 3 s (or from start), press and hold the red and blue button on
         the backside of the device simultaneously.</span
       >
     </li>
     <li>
-      <span>Hold the two buttons for approximately 10s. The Yellow LED should not start blinking!</span>
+      <span>Hold the two buttons for approximately 10 s. The Yellow LED should not start blinking!</span>
     </li>
     <li>
       <span>Remove power from your system.</span>
@@ -102,16 +102,22 @@ guideName: How to reinstall the operating system
       >
     </li>    
     <li><span>Release the <b>USB-C Recvry</b> push button. Older Home Assistant Yellow versions: Un-bridge JP2. </span></li>
-    <li><span>Run rpiboot on your PC and let it run through. Afterwards, the green LED should be on.</span></li>
+    <li><span>Run rpiboot on your PC and let it run through.<ul>
+      <li>If you are on a Windows, it might ask you if you want to reformat the disk. Select <b>Cancel</b> each time.</li>
+      <li><span>Afterwards, the green LED should be on.</span></li></ul>
+    </span></li>
     <li>
       <span
-        >Run the Raspberry Pi Imager and flash the <b>Home Assistant OS Installer for Yellow</b> onto
-        the eMMC ("RPi-MSD"). Refer to 
+        >To flash the <b>Home Assistant OS Installer for Yellow</b> onto
+        the eMMC ("RPi-MSD"), run the Raspberry Pi Imager. Refer to 
         <a href="/power-supply/#installing-the-raspberry-pi-imager">
-          Step 1 through 5</a> from the <b>Installing Home Assistant Software on Kit</b> procedure for the exact steps.
-        Windows might bring up a message asking to insert a disk, this message can be closed. Ignore the
-        Raspberry Pi Imager prompt to remove the SD card. Select <b>Continue</b> and
-        close the Raspberry Pi Installer.
+          Step 1 through 5</a> from the <b>Installing Home Assistant Software on Kit</b> procedure for the exact steps.<ul>
+            <li>Windows might bring up a message asking to insert a disk. Close this message. </li>
+            <li>Ignore the
+              Raspberry Pi Imager prompt to remove the SD card.</li>
+              <li>Select <b>Continue</b> and
+                close the Raspberry Pi Installer.</li>
+          </ul>
       </span>
     </li>
     <li>

--- a/src/procedures/procedures.11tydata.yaml
+++ b/src/procedures/procedures.11tydata.yaml
@@ -221,6 +221,7 @@ proceduresInstallingHAOS:
           <li>Once the installer is ready, the yellow LED is on constantly.</li>
           <li>Installation will start automatically after 5 seconds.</li>
           <li class="info">If the yellow LED does not start blinking steadily after a few seconds, but stays on constantly: This indicates that there might be a network issue.</li>
+          <li class="info">If the LED keeps blinking in a heartbeat pattern for an extended period of time, this could indicate that the installer cannot connect to the internet. Follow <a href="/guides/install-yellow-light-keeps-flashing-in-heartbeat/" target="_blank">this procedure</a> to troubleshoot.</li>
         </ul>
     - title: Waiting
       image: led-patter-install.webp


### PR DESCRIPTION
- This troubelshooting procedure applies if during the installation of the OS on the yellow kit, the yellow LED never gets out of the hearbeat pattern
- Remove troubelshooting link from docs page, as this could be misleading people to apply this procedure even if they are not coming from an installation on kit
- Add info to cancel the dialog to reformat disk on windows
- Instead, add link to troubleshooting procedure from within Yellow Kit installation procedure