### PR TITLE
Rename contact to support

### DIFF
--- a/src/_includes/base.liquid
+++ b/src/_includes/base.liquid
@@ -118,7 +118,7 @@ Home Assistant Yellow
       <div class="footer">
         <div>
           Home&nbsp;Assistant Yellow &nbsp; – &nbsp;
-          <a href="mailto:yellow@home-assistant.io">Contact</a>
+          <a href="mailto:yellow@home-assistant.io">Support</a>
           &nbsp; – &nbsp;
           <a href="https://www.github.com/home-assistant" target="_blank"
             >GitHub</a


### PR DESCRIPTION
- Feedback support team:
  - On the main documentation page, on the bottom, there is a Contact (No support) link
  - but on this page, Contact is supposed to be for support. This is inconsistent.