### PR TITLE
Add note about Screen's EACCES behavior

### DIFF
--- a/src/guides/use-serial-console-linux-macos.html
+++ b/src/guides/use-serial-console-linux-macos.html
@@ -42,7 +42,7 @@ guideName: Using the serial console for debugging (Linux/macOS)
     <li>
       <span>Start GNU Screen and point it to this USB port. E.g.:
         <pre><code>screen /dev/ttyUSB0 115200</code></pre>
-        <p><b>Note:</b> If your account does not have permission to access serial ports, you may have to run the command with <code>sudo</code>.</p>
+        <p><b>Note:</b> If your account does not have permission to access serial ports, you may have to run the command with <code>sudo</code>. If Screen immediately prints <code>[screen is terminating]</code>, this is likely the problem.</p>
         <p><b>Note:</b> Screen typically doesn't display anything on startup. You see only the cursor
           on the top left of the window.</p>
       </span>


### PR DESCRIPTION
See the diff; it's pretty obvious. The problem this patch is trying to solve is that Screen _literally does not print an error message_, it just terminates without explanation (at least on my Fedora Silverblue system).

I went to considerable trouble (read: had a bunch of fun messing around with `strace`) to confirm that Screen was literally getting `EACCES`.

(For those curious: `sudo strace -fu $(whoami) -o strace.log screen /dev/ttyUSB0` and then poke around in `strace.log`!)