### PR TITLE
Change baud rate in UART documentation

### DIFF
--- a/src/guides/use-serial-console-linux-macos.html
+++ b/src/guides/use-serial-console-linux-macos.html
@@ -45,7 +45,7 @@ guideName: Using the serial console for debugging (Linux/macOS)
     </li>
     <li>
       <span>Start GNU Screen and point it to this USB port. E.g.:
-        <pre><code>screen /dev/ttyUSB0 115200</code></pre>
+        <pre><code>screen /dev/ttyUSB0 38400</code></pre>
         <p><b>Troubleshooting:</b> If your account does not have permission to access serial ports, you may have to run the command with <code>sudo</code>. If Screen immediately prints <code>[screen is terminating]</code>, this is likely the problem.</p>
         <p><b>Note:</b> Screen typically doesn't display anything on startup. You see only the cursor
           in the top left corner of the window.</p>


### PR DESCRIPTION
The baud rate for the UART on the Yellow was changed in a recent HASS update. This updates the documentation to match.

I was unable to pinpoint the commit to the OS in which this change happened but I assume it was changed intentionally.

This PR doesn't update the Windows documentation as the baud rate there is not in the text but only in a screenshot for which I do not have the Windows install (or Photoshop skills) to update. 